### PR TITLE
Restyle the feed as a full-bleed vertical drop feed, black + lime

### DIFF
--- a/app/lib/screens/capture_screen.dart
+++ b/app/lib/screens/capture_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 
+import '../theme.dart';
 import 'publish_screen.dart';
 
 /// Entry point for the core "snap it" loop: opens the camera immediately,
@@ -44,7 +45,17 @@ class _CaptureScreenState extends State<CaptureScreen> {
   @override
   Widget build(BuildContext context) {
     return const Scaffold(
-      body: Center(child: CircularProgressIndicator()),
+      backgroundColor: S8llColors.black,
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircularProgressIndicator(color: S8llColors.lime),
+            SizedBox(height: 16),
+            Text('Opening camera…', style: TextStyle(color: Colors.white70)),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/app/lib/screens/feed_screen.dart
+++ b/app/lib/screens/feed_screen.dart
@@ -8,11 +8,20 @@ import '../services/listing_filter.dart';
 import '../services/saved_searches_repository.dart';
 import '../state/app_state.dart';
 import '../theme.dart';
-import '../widgets/listing_card.dart';
 import 'listing_detail_screen.dart';
 
 const _maxPriceOptions = <int?>[null, 2500, 5000, 10000, 25000];
 
+/// The main feed — a full-bleed, one-listing-per-screen vertical drop feed
+/// (swipe up for the next one) rather than a scrolling list, so the photo
+/// and the live countdown always own the whole screen. Always renders dark
+/// regardless of the app's light/dark setting: a short-form feed reads as
+/// itself against black the way it doesn't against an off-white page.
+///
+/// Search/category/price filtering and saved searches are all real and
+/// unchanged from before — just moved into a sheet behind the search icon
+/// instead of sitting permanently on screen, since a drop feed has no room
+/// for a filter bar above every card.
 class FeedScreen extends StatefulWidget {
   const FeedScreen({super.key});
 
@@ -76,6 +85,123 @@ class _FeedScreenState extends State<FeedScreen> {
     }
   }
 
+  Future<void> _openFilters(String uid) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: S8llColors.charcoal,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(S8llRadius.md)),
+      ),
+      builder: (sheetContext) {
+        return StatefulBuilder(
+          builder: (sheetContext, setSheetState) {
+            void update(VoidCallback fn) {
+              setState(fn);
+              setSheetState(() {});
+            }
+
+            return Padding(
+              padding: EdgeInsets.only(
+                left: S8llSpacing.lg,
+                right: S8llSpacing.lg,
+                top: S8llSpacing.lg,
+                bottom: MediaQuery.of(sheetContext).viewInsets.bottom + S8llSpacing.lg,
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Search & filter', style: Theme.of(sheetContext).textTheme.titleLarge),
+                  const SizedBox(height: S8llSpacing.lg),
+                  TextField(
+                    controller: _searchController,
+                    onChanged: (_) => update(() {}),
+                    style: const TextStyle(color: S8llColors.white),
+                    decoration: const InputDecoration(
+                      hintText: 'Search listings',
+                      prefixIcon: Icon(Icons.search),
+                    ),
+                  ),
+                  const SizedBox(height: S8llSpacing.md),
+                  SizedBox(
+                    height: 40,
+                    child: ListView(
+                      scrollDirection: Axis.horizontal,
+                      children: [
+                        _FilterChip(
+                          label: 'All',
+                          selected: _category == null,
+                          onTap: () => update(() => _category = null),
+                        ),
+                        for (final category in ListingCategory.values)
+                          Padding(
+                            padding: const EdgeInsets.only(left: S8llSpacing.xs),
+                            child: _FilterChip(
+                              label: category.label,
+                              selected: _category == category,
+                              onTap: () => update(() => _category = category),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: S8llSpacing.sm),
+                  SizedBox(
+                    height: 40,
+                    child: ListView(
+                      scrollDirection: Axis.horizontal,
+                      children: [
+                        for (final option in _maxPriceOptions)
+                          Padding(
+                            padding: const EdgeInsets.only(right: S8llSpacing.xs),
+                            child: _FilterChip(
+                              label: option == null ? 'Any price' : 'Under £${option ~/ 100}',
+                              selected: _maxPriceCents == option,
+                              onTap: () => update(() => _maxPriceCents = option),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                  if (_hasActiveFilters) ...[
+                    const SizedBox(height: S8llSpacing.md),
+                    TextButton.icon(
+                      onPressed: () => _saveSearch(uid),
+                      icon: const Icon(Icons.bookmark_add_outlined, size: 18),
+                      label: const Text('Save this search'),
+                    ),
+                  ],
+                  if (_savedSearches.isNotEmpty) ...[
+                    const SizedBox(height: S8llSpacing.sm),
+                    const Text('Saved searches', style: TextStyle(color: S8llColors.grey, fontSize: 12)),
+                    const SizedBox(height: S8llSpacing.xs),
+                    Wrap(
+                      spacing: S8llSpacing.xs,
+                      runSpacing: S8llSpacing.xs,
+                      children: [
+                        for (final search in _savedSearches)
+                          InputChip(
+                            label: Text(search.query.isEmpty ? 'Saved search' : search.query),
+                            onPressed: () {
+                              _applySearch(search);
+                              setSheetState(() {});
+                            },
+                            onDeleted: () =>
+                                context.read<SavedSearchesRepository>().delete(search.id),
+                          ),
+                      ],
+                    ),
+                  ],
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final appState = context.watch<AppState>();
@@ -90,104 +216,18 @@ class _FeedScreenState extends State<FeedScreen> {
     );
 
     return Scaffold(
-      appBar: AppBar(title: const Text('S8LL')),
-      body: Column(
+      backgroundColor: S8llColors.black,
+      body: Stack(
         children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(S8llSpacing.md, S8llSpacing.sm, S8llSpacing.md, 0),
-            child: TextField(
-              controller: _searchController,
-              onChanged: (_) => setState(() {}),
-              decoration: const InputDecoration(
-                hintText: 'Search listings',
-                prefixIcon: Icon(Icons.search),
-              ),
-            ),
-          ),
-          SizedBox(
-            height: 40,
-            child: ListView(
-              scrollDirection: Axis.horizontal,
-              padding: const EdgeInsets.symmetric(horizontal: S8llSpacing.md, vertical: S8llSpacing.sm),
-              children: [
-                _FilterChip(
-                  label: 'All',
-                  selected: _category == null,
-                  onTap: () => setState(() => _category = null),
-                ),
-                for (final category in ListingCategory.values)
-                  Padding(
-                    padding: const EdgeInsets.only(left: S8llSpacing.xs),
-                    child: _FilterChip(
-                      label: category.label,
-                      selected: _category == category,
-                      onTap: () => setState(() => _category = category),
-                    ),
-                  ),
-              ],
-            ),
-          ),
-          SizedBox(
-            height: 40,
-            child: ListView(
-              scrollDirection: Axis.horizontal,
-              padding: const EdgeInsets.symmetric(horizontal: S8llSpacing.md),
-              children: [
-                for (final option in _maxPriceOptions)
-                  Padding(
-                    padding: const EdgeInsets.only(right: S8llSpacing.xs),
-                    child: _FilterChip(
-                      label: option == null ? 'Any price' : 'Under £${option ~/ 100}',
-                      selected: _maxPriceCents == option,
-                      onTap: () => setState(() => _maxPriceCents = option),
-                    ),
-                  ),
-              ],
-            ),
-          ),
-          if (_savedSearches.isNotEmpty || _hasActiveFilters)
-            Padding(
-              padding: const EdgeInsets.fromLTRB(S8llSpacing.md, S8llSpacing.sm, S8llSpacing.md, 0),
-              child: Row(
-                children: [
-                  if (_hasActiveFilters)
-                    TextButton.icon(
-                      onPressed: () => _saveSearch(uid),
-                      icon: const Icon(Icons.bookmark_add_outlined, size: 18),
-                      label: const Text('Save this search'),
-                    ),
-                  Expanded(
-                    child: SizedBox(
-                      height: 32,
-                      child: ListView(
-                        scrollDirection: Axis.horizontal,
-                        children: [
-                          for (final search in _savedSearches)
-                            Padding(
-                              padding: const EdgeInsets.only(right: S8llSpacing.xs),
-                              child: InputChip(
-                                label: Text(search.query.isEmpty ? 'Saved search' : search.query),
-                                onPressed: () => _applySearch(search),
-                                onDeleted: () =>
-                                    context.read<SavedSearchesRepository>().delete(search.id),
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          Expanded(
+          Positioned.fill(
             child: listings.isEmpty
-                ? const Center(child: Text('Nothing matches right now.'))
-                : ListView.builder(
-                    padding: const EdgeInsets.only(bottom: 24, top: S8llSpacing.sm),
+                ? _EmptyFeed(hasFilters: _hasActiveFilters)
+                : PageView.builder(
+                    scrollDirection: Axis.vertical,
                     itemCount: listings.length,
                     itemBuilder: (context, index) {
                       final listing = listings[index];
-                      return ListingCard(
+                      return _DropCard(
                         listing: listing,
                         onTap: () => Navigator.of(context).push(
                           MaterialPageRoute(builder: (_) => ListingDetailScreen(listing: listing)),
@@ -196,7 +236,292 @@ class _FeedScreenState extends State<FeedScreen> {
                     },
                   ),
           ),
+          SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: S8llSpacing.lg, vertical: S8llSpacing.sm),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text(
+                    'S8LL',
+                    style: TextStyle(
+                      color: S8llColors.lime,
+                      fontWeight: FontWeight.w900,
+                      fontSize: 24,
+                      letterSpacing: -0.5,
+                    ),
+                  ),
+                  Row(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+                        decoration: BoxDecoration(
+                          color: S8llColors.charcoal.withValues(alpha: 0.85),
+                          borderRadius: BorderRadius.circular(999),
+                        ),
+                        child: Text(
+                          '${visible.length} live now',
+                          style: const TextStyle(
+                            color: S8llColors.white,
+                            fontWeight: FontWeight.w700,
+                            fontSize: 12,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: S8llSpacing.sm),
+                      GestureDetector(
+                        onTap: () => _openFilters(uid),
+                        child: Container(
+                          padding: const EdgeInsets.all(8),
+                          decoration: BoxDecoration(
+                            color: _hasActiveFilters
+                                ? S8llColors.lime
+                                : S8llColors.charcoal.withValues(alpha: 0.85),
+                            shape: BoxShape.circle,
+                          ),
+                          child: Icon(
+                            Icons.search,
+                            size: 18,
+                            color: _hasActiveFilters ? S8llColors.black : S8llColors.white,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
         ],
+      ),
+    );
+  }
+}
+
+class _DropCard extends StatelessWidget {
+  const _DropCard({required this.listing, required this.onTap});
+
+  final Listing listing;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          _FullBleedPhoto(url: listing.photoUrl),
+          DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                stops: const [0.5, 1],
+                colors: [Colors.transparent, Colors.black.withValues(alpha: 0.85)],
+              ),
+            ),
+          ),
+          if (listing.status == ListingStatus.sold)
+            const Positioned(
+              top: 96,
+              left: 20,
+              child: _SoldBadge(),
+            )
+          else
+            Positioned(
+              top: 96,
+              left: 20,
+              child: _PulsingCountdown(listing: listing),
+            ),
+          Positioned(
+            left: 20,
+            right: 20,
+            bottom: 28,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  listing.watcherCount > 0
+                      ? '${listing.sellerName} · ${listing.watcherCount} watching'
+                      : listing.sellerName,
+                  style: const TextStyle(color: Colors.white70, fontSize: 13),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '£${listing.priceInPounds.toStringAsFixed(0)}',
+                  style: const TextStyle(
+                    color: S8llColors.lime,
+                    fontWeight: FontWeight.w900,
+                    fontSize: 44,
+                    height: 1.0,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  listing.title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(color: Colors.white, fontSize: 17, fontWeight: FontWeight.w600),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FullBleedPhoto extends StatelessWidget {
+  const _FullBleedPhoto({required this.url});
+
+  final String? url;
+
+  @override
+  Widget build(BuildContext context) {
+    if (url == null || url!.isEmpty) {
+      return const ColoredBox(
+        color: S8llColors.charcoal,
+        child: Center(
+          child: Icon(Icons.shopping_bag_outlined, size: 64, color: S8llColors.greyLow),
+        ),
+      );
+    }
+    return Image.network(
+      url!,
+      fit: BoxFit.cover,
+      loadingBuilder: (context, child, progress) {
+        if (progress == null) return child;
+        return const ColoredBox(
+          color: S8llColors.charcoal,
+          child: Center(child: CircularProgressIndicator(color: S8llColors.lime)),
+        );
+      },
+      errorBuilder: (context, error, stack) => const ColoredBox(
+        color: S8llColors.charcoal,
+        child: Center(
+          child: Icon(Icons.broken_image_outlined, size: 64, color: S8llColors.greyLow),
+        ),
+      ),
+    );
+  }
+}
+
+/// A pulsing pill showing the listing's real time-remaining ("2h left",
+/// "45m left" — turning red under 30 minutes), same text as [CountdownBadge]
+/// elsewhere in the app. The pulse is decoration; the number is real —
+/// there's no per-second countdown to show, so this never claims one.
+class _PulsingCountdown extends StatefulWidget {
+  const _PulsingCountdown({required this.listing});
+
+  final Listing listing;
+
+  @override
+  State<_PulsingCountdown> createState() => _PulsingCountdownState();
+}
+
+class _PulsingCountdownState extends State<_PulsingCountdown> with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _scale;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: const Duration(milliseconds: 900))
+      ..repeat(reverse: true);
+    _scale = Tween<double>(begin: 1, end: 1.08).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final remaining = widget.listing.remaining(DateTime.now());
+    final expiring = remaining.inMinutes <= 30 && remaining > Duration.zero;
+    final label = remaining == Duration.zero
+        ? 'Expired'
+        : remaining.inHours >= 1
+            ? '${remaining.inHours}h left'
+            : '${remaining.inMinutes}m left';
+    return ScaleTransition(
+      scale: _scale,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        decoration: BoxDecoration(
+          color: expiring ? Colors.redAccent : S8llColors.lime,
+          borderRadius: BorderRadius.circular(999),
+          boxShadow: [
+            BoxShadow(
+              color: (expiring ? Colors.redAccent : S8llColors.lime).withValues(alpha: 0.5),
+              blurRadius: 16,
+            ),
+          ],
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            color: expiring ? Colors.white : S8llColors.black,
+            fontWeight: FontWeight.w800,
+            fontSize: 15,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SoldBadge extends StatelessWidget {
+  const _SoldBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(999)),
+      child: const Text(
+        'SOLD',
+        style: TextStyle(color: Colors.black, fontWeight: FontWeight.w800, fontSize: 15, letterSpacing: 1),
+      ),
+    );
+  }
+}
+
+class _EmptyFeed extends StatelessWidget {
+  const _EmptyFeed({required this.hasFilters});
+
+  final bool hasFilters;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: S8llSpacing.xl),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              hasFilters ? 'Nothing matches right now' : 'Nothing dropping yet',
+              style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w700),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              hasFilters
+                  ? 'Try clearing a filter or searching something else.'
+                  : 'Tap the camera below to be the first to list.',
+              style: const TextStyle(color: Colors.white54, fontSize: 13),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -211,12 +536,17 @@ class _FilterChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FilterChip(
-      label: Text(label),
-      selected: selected,
-      onSelected: (_) => onTap(),
-      selectedColor: S8llColors.limeSoft,
-      checkmarkColor: S8llColors.lime,
+    return Padding(
+      padding: const EdgeInsets.only(right: S8llSpacing.xs),
+      child: FilterChip(
+        label: Text(label),
+        selected: selected,
+        onSelected: (_) => onTap(),
+        backgroundColor: S8llColors.charcoalHigh,
+        labelStyle: const TextStyle(color: S8llColors.white),
+        selectedColor: S8llColors.limeSoft,
+        checkmarkColor: S8llColors.lime,
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary

- Redesigns the main feed from a scrolling list of cards into a one-listing-per-screen vertical `PageView` (swipe up for the next one), always dark regardless of the app's light/dark setting — a short-form feed reads as itself against black the way it doesn't against an off-white page.
- Every number on it is real: the countdown pill shows the listing's actual `remaining()` ("Xh left" / "Xm left", red under 30 minutes — the same text `CountdownBadge` already showed, just wrapped in a pulse for energy), "N live now" is the real unblocked-listings count, and price/watcher counts are the same real data `ListingCard` rendered before.
- Search, category/price filters, and saved searches are unchanged functionally — moved into a bottom sheet behind a search icon since a full-bleed card has no room for a permanent filter bar. Tapping a card still opens the real `ListingDetailScreen`.
- Gives `CaptureScreen`'s brief loading state the same black/lime treatment instead of a bare default spinner.

## What this deliberately does *not* do

Does not add a fake "AI scanning" step to capture. There's no real object-detection or auto-pricing feature in this app, so an animated "Detected: Wooden Board, 23 sold, avg £45" would be fabricated output presented as real analysis. The publish form after capture is untouched — it already asks for exactly the real fields a listing needs.

Also does not touch the countdown semantics: S8LL listings stay live for 8 hours (`Listing.liveFor` defaults to `Duration(hours: 8)`), not 8 seconds — that's the real "8" behind the name. The pill shows real hours/minutes remaining, never a fabricated per-second count.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 32 tests pass
- [ ] Manual pass on a fresh APK build — swipe through the feed, open the filter sheet, save/apply a saved search, tap into a listing, confirm the capture-loading screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195suo1jDY8EYgt9qC2apSs

---
_Generated by [Claude Code](https://claude.ai/code/session_0195suo1jDY8EYgt9qC2apSs)_