### PR TITLE
Fix permission-denied crash opening your own listing, speed up publish

### DIFF
--- a/app/lib/screens/capture_screen.dart
+++ b/app/lib/screens/capture_screen.dart
@@ -25,7 +25,15 @@ class _CaptureScreenState extends State<CaptureScreen> {
     final picker = ImagePicker();
     XFile? photo;
     try {
-      photo = await picker.pickImage(source: ImageSource.camera, imageQuality: 85);
+      // maxWidth resizes the image itself — imageQuality alone only
+      // re-compresses it at full camera resolution (often 3000px+ wide,
+      // several MB), which is what was making publishing slow: the upload
+      // had to move that whole file before Storage would return a URL.
+      photo = await picker.pickImage(
+        source: ImageSource.camera,
+        imageQuality: 85,
+        maxWidth: 1600,
+      );
     } catch (_) {
       photo = null;
     }

--- a/app/lib/screens/listing_detail_screen.dart
+++ b/app/lib/screens/listing_detail_screen.dart
@@ -85,7 +85,7 @@ class _ListingDetailScreenState extends State<ListingDetailScreen> {
 
     final offers = context.read<OffersRepository>();
     if (isMine) {
-      _pendingOffersSub = offers.pendingOffersForListing(widget.listing.id).listen((pending) {
+      _pendingOffersSub = offers.pendingOffersForListing(widget.listing.id, uid).listen((pending) {
         if (mounted) setState(() => _pendingOffers = pending);
       });
     } else if (!isSold) {

--- a/app/lib/services/offers_repository.dart
+++ b/app/lib/services/offers_repository.dart
@@ -26,9 +26,18 @@ class OffersRepository {
 
   /// Pending offers a seller has received on one of their listings, for
   /// them to accept or decline.
-  Stream<List<Offer>> pendingOffersForListing(String listingId) {
+  ///
+  /// Filtering by [sellerId] isn't just belt-and-braces — firestore.rules
+  /// can only allow a list query when every field it checks (here,
+  /// `sellerId == request.auth.uid`) is also a filter on the query itself,
+  /// so Firestore can prove the rule holds for every possible result.
+  /// Without this filter the query is provably unsafe from Firestore's
+  /// point of view and the whole request is denied, even for the listing's
+  /// actual seller.
+  Stream<List<Offer>> pendingOffersForListing(String listingId, String sellerId) {
     return _offers
         .where('listingId', isEqualTo: listingId)
+        .where('sellerId', isEqualTo: sellerId)
         .where('status', isEqualTo: OfferStatus.pending.name)
         .snapshots()
         .map((snap) => snap.docs.map(Offer.fromFirestore).toList());


### PR DESCRIPTION
## Summary

- **Fixes the `[cloud_firestore/permission-denied]` crash** hit when opening a listing's detail page as its own seller. Root cause: `pendingOffersForListing()` queried `offers` filtered only by `listingId` + `status`, but `firestore.rules` requires proving `sellerId == request.auth.uid` for every possible result of a *list* query — Firestore can only prove that when the query itself also filters on `sellerId`. Without it, the query is unprovable and the whole request is denied, even for the listing's actual seller.
  - Verified this was the real cause (not a guess) by pulling the live deployed rules directly (they match this repo byte-for-byte) and checking Firebase App Check's enforcement mode via the Admin API (`UNENFORCED` on Firestore/Storage/Auth) before landing on the query/rule mismatch as the actual root cause.
  - Fix: `pendingOffersForListing` now takes and filters on `sellerId` too.
- **Speeds up publishing.** The capture flow only quality-compressed (`imageQuality: 85`) at full camera resolution — often 3000px+ wide, several MB — never resizing dimensions. Added `maxWidth: 1600`, so the file that has to upload before Storage returns a URL is dramatically smaller.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 32 tests pass
- [ ] Manual: open your own live listing's detail page (previously crashed), confirm it loads; publish a new listing and confirm it's noticeably faster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195suo1jDY8EYgt9qC2apSs

---
_Generated by [Claude Code](https://claude.ai/code/session_0195suo1jDY8EYgt9qC2apSs)_