### PR TITLE
Fix feed's price/title being hidden behind the camera FAB

### DIFF
--- a/app/lib/screens/feed_screen.dart
+++ b/app/lib/screens/feed_screen.dart
@@ -337,7 +337,11 @@ class _DropCard extends StatelessWidget {
           Positioned(
             left: 20,
             right: 20,
-            bottom: 28,
+            // RootShell's camera FAB floats centerFloat — its footprint is
+            // ~72px above the bottom nav bar (16 margin + 56 FAB height).
+            // bottom: 28 used to put this block's lower half directly
+            // behind it, invisible under an opaque button.
+            bottom: 80,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
## Summary

Real bug found from a live screenshot showing no price/title anywhere on the feed, despite the code drawing them.

`RootShell`'s camera button uses `floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat`, which gives it a ~72px footprint above the bottom nav bar (16px margin + 56px FAB height). The feed card's price/title block was anchored at `bottom: 28`, putting its lower half directly behind that opaque button — invisible regardless of how bright or dark the listing's photo is. Moved the anchor to `bottom: 80` so the whole block clears the FAB.

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 32 tests pass
- [ ] Manual: open the feed, confirm price/title are visible on every card, not hidden behind the camera button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195suo1jDY8EYgt9qC2apSs

---
_Generated by [Claude Code](https://claude.ai/code/session_0195suo1jDY8EYgt9qC2apSs)_