### PR TITLE
Quick-offer chips + expiring-listing bump reminder

### DIFF
--- a/app/lib/screens/listing_detail_screen.dart
+++ b/app/lib/screens/listing_detail_screen.dart
@@ -109,20 +109,54 @@ class _ListingDetailScreenState extends State<ListingDetailScreen> {
     super.dispose();
   }
 
+  /// Whole-pound quick-offer suggestions (90%/80%/70% of the asking price),
+  /// deduplicated and kept strictly below the asking price so every chip is
+  /// a valid offer on its own.
+  List<int> _quickOfferPounds() {
+    final priceInPounds = widget.listing.priceInPounds;
+    final pounds = <int>{
+      for (final ratio in [0.9, 0.8, 0.7]) (priceInPounds * ratio).round(),
+    }.where((p) => p > 0 && p < priceInPounds).toList()
+      ..sort((a, b) => b.compareTo(a));
+    return pounds;
+  }
+
   Future<void> _showMakeOfferDialog() async {
     final controller = TextEditingController();
+    final quickOfferPounds = _quickOfferPounds();
     final offerPounds = await showDialog<double>(
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Make an offer'),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          keyboardType: const TextInputType.numberWithOptions(decimal: true),
-          decoration: InputDecoration(
-            prefixText: '£',
-            hintText: 'Less than £${widget.listing.priceInPounds.toStringAsFixed(0)}',
-          ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (quickOfferPounds.isNotEmpty) ...[
+              Text('Quick offer', style: Theme.of(context).textTheme.bodySmall),
+              const SizedBox(height: S8llSpacing.xs),
+              Wrap(
+                spacing: S8llSpacing.sm,
+                children: [
+                  for (final pounds in quickOfferPounds)
+                    ActionChip(
+                      label: Text('£$pounds'),
+                      onPressed: () => controller.text = '$pounds',
+                    ),
+                ],
+              ),
+              const SizedBox(height: S8llSpacing.md),
+            ],
+            TextField(
+              controller: controller,
+              autofocus: true,
+              keyboardType: const TextInputType.numberWithOptions(decimal: true),
+              decoration: InputDecoration(
+                prefixText: '£',
+                hintText: 'Less than £${widget.listing.priceInPounds.toStringAsFixed(0)}',
+              ),
+            ),
+          ],
         ),
         actions: [
           TextButton(

--- a/functions/src/__tests__/notifications.test.ts
+++ b/functions/src/__tests__/notifications.test.ts
@@ -1,4 +1,4 @@
-import { FieldValue } from "firebase-admin/firestore";
+import { FieldValue, Timestamp } from "firebase-admin/firestore";
 import { FakeFirestore } from "./helpers/fakeFirestore";
 import { makeFakeMessaging } from "./helpers/fakeMessaging";
 
@@ -15,6 +15,7 @@ import {
   onOrderCreated,
   matchesSavedSearch,
   onNewListingMatchSavedSearches,
+  remindSellersOfExpiringListings,
 } from "../notifications";
 
 const BUYER = "buyer-1";
@@ -217,5 +218,66 @@ describe("onNewListingMatchSavedSearches", () => {
     expect(fakeMessaging.sendEachForMulticast).toHaveBeenCalledWith(
       expect.objectContaining({ tokens: ["match-token"] })
     );
+  });
+});
+
+describe("remindSellersOfExpiringListings", () => {
+  const run = () =>
+    remindSellersOfExpiringListings.run({ scheduleTime: new Date().toISOString() } as never);
+
+  beforeEach(() => {
+    fakeDb.seed(`users/${SELLER}`, { fcmTokens: ["seller-token"] });
+  });
+
+  it("reminds the seller and marks reminderSent for a listing expiring in ~27 minutes", async () => {
+    fakeDb.seed(`listings/${LISTING}`, {
+      sellerId: SELLER,
+      title: "Nike Air Max 90",
+      status: "live",
+      postedAt: Timestamp.now(),
+      liveForSeconds: 27 * 60, // expires in 27 minutes — inside the 25-30 window
+    });
+
+    await run();
+
+    expect(fakeMessaging.sendEachForMulticast).toHaveBeenCalledTimes(1);
+    expect(fakeMessaging.sendEachForMulticast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tokens: ["seller-token"],
+        notification: expect.objectContaining({ title: "Listing expiring soon" }),
+        data: { type: "expiring-soon", listingId: LISTING },
+      })
+    );
+    expect(fakeDb.store.get(`listings/${LISTING}`)?.reminderSent).toBe(true);
+  });
+
+  it("does not remind again once reminderSent is already true", async () => {
+    fakeDb.seed(`listings/${LISTING}`, {
+      sellerId: SELLER,
+      title: "Nike Air Max 90",
+      status: "live",
+      postedAt: Timestamp.now(),
+      liveForSeconds: 27 * 60,
+      reminderSent: true,
+    });
+
+    await run();
+
+    expect(fakeMessaging.sendEachForMulticast).not.toHaveBeenCalled();
+  });
+
+  it("leaves a listing untouched when it isn't close to expiring yet", async () => {
+    fakeDb.seed(`listings/${LISTING}`, {
+      sellerId: SELLER,
+      title: "Nike Air Max 90",
+      status: "live",
+      postedAt: Timestamp.now(),
+      liveForSeconds: 8 * 60 * 60, // expires in 8 hours — well outside the window
+    });
+
+    await run();
+
+    expect(fakeMessaging.sendEachForMulticast).not.toHaveBeenCalled();
+    expect(fakeDb.store.get(`listings/${LISTING}`)?.reminderSent).toBeUndefined();
   });
 });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7,4 +7,5 @@ export {
   onOfferResponded,
   onOrderCreated,
   onNewListingMatchSavedSearches,
+  remindSellersOfExpiringListings,
 } from "./notifications";

--- a/functions/src/notifications.ts
+++ b/functions/src/notifications.ts
@@ -1,6 +1,7 @@
 import { onDocumentCreated, onDocumentUpdated } from "firebase-functions/v2/firestore";
+import { onSchedule } from "firebase-functions/v2/scheduler";
 import { logger } from "firebase-functions";
-import { FieldValue } from "firebase-admin/firestore";
+import { FieldValue, Timestamp } from "firebase-admin/firestore";
 import { db, messaging } from "./admin";
 
 const COMPONENT = "notifications";
@@ -191,3 +192,65 @@ export const onNewListingMatchSavedSearches = onDocumentCreated(
     }
   }
 );
+
+// Listings expire `liveForSeconds` after `postedAt` (there's no stored
+// `expiryAt`), and how long that is can vary per listing, so it's computed
+// per-doc below rather than pushed into the query. A reminder should land
+// once, with enough runway for the seller to act — 25-30 minutes out — and
+// a 10-minute schedule comfortably covers that window without doubling up.
+const EXPIRY_REMINDER_WINDOW_START_MINUTES = 25;
+const EXPIRY_REMINDER_WINDOW_END_MINUTES = 30;
+
+/**
+ * Reminds sellers to bump a listing shortly before it expires. Fetches every
+ * live listing (a single-field equality query, so no composite index is
+ * needed) and filters in memory for the ones landing in the reminder window
+ * — the same small-demo-scale tradeoff `onNewListingMatchSavedSearches`
+ * above makes, and fine at this app's current scale.
+ */
+export const remindSellersOfExpiringListings = onSchedule("every 10 minutes", async () => {
+  const now = Date.now();
+  const windowStartMs = now + EXPIRY_REMINDER_WINDOW_START_MINUTES * 60_000;
+  const windowEndMs = now + EXPIRY_REMINDER_WINDOW_END_MINUTES * 60_000;
+
+  const liveSnap = await db.collection("listings").where("status", "==", "live").get();
+
+  const expiring = liveSnap.docs.filter((doc) => {
+    const listing = doc.data();
+    if (listing.reminderSent === true) return false;
+
+    const postedAt = listing.postedAt as Timestamp | undefined;
+    const liveForSeconds = listing.liveForSeconds as number | undefined;
+    if (!postedAt || liveForSeconds == null) return false;
+
+    const expiresAtMs = postedAt.toMillis() + liveForSeconds * 1000;
+    return expiresAtMs >= windowStartMs && expiresAtMs <= windowEndMs;
+  });
+
+  await Promise.all(
+    expiring.map(async (doc) => {
+      const listing = doc.data();
+      const listingId = doc.ref.path.split("/").pop() as string;
+      const title = (listing.title as string | undefined) ?? "Your listing";
+
+      await sendPushToUser(
+        listing.sellerId as string,
+        {
+          title: "Listing expiring soon",
+          body: `${title} expires in ~30 minutes — bump it to keep it live.`,
+        },
+        { type: "expiring-soon", listingId }
+      );
+      // Targeted merge so this touches only `reminderSent`, not the rest of
+      // the listing doc — same reasoning as the arrayRemove merge above.
+      await doc.ref.set({ reminderSent: true }, { merge: true });
+    })
+  );
+
+  if (expiring.length > 0) {
+    logger.info("Sent expiring-soon reminders", {
+      component: COMPONENT,
+      count: expiring.length,
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Two independent features, built in parallel by background agents against the real schema and existing conventions, bundled here since they touch entirely separate parts of the codebase (Flutter UI vs. Cloud Functions):

**1. Quick-price preset chips on the make-an-offer dialog.** Shows 90%/80%/70%-of-asking-price suggestions (whole pounds) above the existing free-text offer field. Tapping a chip fills the text field rather than submitting immediately, so the existing validation, error handling, and `OffersRepository.makeOffer()` call are completely unchanged.

**2. A scheduled reminder for listings expiring soon.** A 10-minute `onSchedule` Cloud Function finds live listings expiring in 25-30 minutes and pushes a "bump it" reminder to the seller via the existing `sendPushToUser` helper, marking `reminderSent` so each listing is only reminded once. No new composite index needed (single-field equality query, expiry filtered in memory — same tradeoff `onNewListingMatchSavedSearches` already makes at this app's scale).

## Test plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 32 tests pass
- [x] `functions`: `npm run build` — clean
- [x] `functions`: `npm test` — 49/49 pass (46 baseline + 3 new for the reminder function)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195suo1jDY8EYgt9qC2apSs