### PR TITLE
Feed as a scrollable grid, and demo accounts for testing

### DIFF
--- a/app/lib/screens/auth_screen.dart
+++ b/app/lib/screens/auth_screen.dart
@@ -2,6 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
 import '../services/auth_service.dart';
+import '../services/demo_data.dart';
 import '../theme.dart';
 
 class AuthScreen extends StatefulWidget {
@@ -55,6 +56,22 @@ class _AuthScreenState extends State<AuthScreen> {
       }
     } on FirebaseAuthException catch (e) {
       setState(() => _error = e.message ?? 'Something went wrong.');
+    } finally {
+      if (mounted) setState(() => _submitting = false);
+    }
+  }
+
+  Future<void> _useDemoAccount(int index) async {
+    setState(() {
+      _submitting = true;
+      _error = null;
+    });
+    try {
+      await useDemoAccount(widget.authService, index);
+    } on FirebaseAuthException catch (e) {
+      setState(() => _error = e.message ?? 'Could not sign into the demo account.');
+    } catch (e) {
+      setState(() => _error = 'Could not sign into the demo account: $e');
     } finally {
       if (mounted) setState(() => _submitting = false);
     }
@@ -140,6 +157,33 @@ class _AuthScreenState extends State<AuthScreen> {
                     child: Text(_isSignUp
                         ? 'Already have an account? Sign in'
                         : 'New here? Create an account'),
+                  ),
+                  const SizedBox(height: 16),
+                  Row(
+                    children: [
+                      Expanded(child: Divider(color: context.s8ll.textSecondary.withValues(alpha: 0.3))),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 12),
+                        child: Text(
+                          'or try a demo account',
+                          style: TextStyle(color: context.s8ll.textSecondary, fontSize: 12),
+                        ),
+                      ),
+                      Expanded(child: Divider(color: context.s8ll.textSecondary.withValues(alpha: 0.3))),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  Wrap(
+                    alignment: WrapAlignment.center,
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      for (var i = 0; i < demoAccounts.length; i++)
+                        OutlinedButton(
+                          onPressed: _submitting ? null : () => _useDemoAccount(i),
+                          child: Text(demoAccounts[i].displayName),
+                        ),
+                    ],
                   ),
                 ],
               ),

--- a/app/lib/screens/feed_screen.dart
+++ b/app/lib/screens/feed_screen.dart
@@ -12,16 +12,15 @@ import 'listing_detail_screen.dart';
 
 const _maxPriceOptions = <int?>[null, 2500, 5000, 10000, 25000];
 
-/// The main feed — a full-bleed, one-listing-per-screen vertical drop feed
-/// (swipe up for the next one) rather than a scrolling list, so the photo
-/// and the live countdown always own the whole screen. Always renders dark
-/// regardless of the app's light/dark setting: a short-form feed reads as
-/// itself against black the way it doesn't against an off-white page.
+/// The main feed — a scrollable 2-column grid so multiple live listings are
+/// visible at once, rather than one full-screen card at a time. Always
+/// renders dark regardless of the app's light/dark setting: a drop feed
+/// reads as itself against black the way it doesn't against an off-white
+/// page.
 ///
 /// Search/category/price filtering and saved searches are all real and
-/// unchanged from before — just moved into a sheet behind the search icon
-/// instead of sitting permanently on screen, since a drop feed has no room
-/// for a filter bar above every card.
+/// unchanged from before — behind the search icon in the header instead of
+/// sitting permanently on screen.
 class FeedScreen extends StatefulWidget {
   const FeedScreen({super.key});
 
@@ -217,27 +216,10 @@ class _FeedScreenState extends State<FeedScreen> {
 
     return Scaffold(
       backgroundColor: S8llColors.black,
-      body: Stack(
-        children: [
-          Positioned.fill(
-            child: listings.isEmpty
-                ? _EmptyFeed(hasFilters: _hasActiveFilters)
-                : PageView.builder(
-                    scrollDirection: Axis.vertical,
-                    itemCount: listings.length,
-                    itemBuilder: (context, index) {
-                      final listing = listings[index];
-                      return _DropCard(
-                        listing: listing,
-                        onTap: () => Navigator.of(context).push(
-                          MaterialPageRoute(builder: (_) => ListingDetailScreen(listing: listing)),
-                        ),
-                      );
-                    },
-                  ),
-          ),
-          SafeArea(
-            child: Padding(
+      body: SafeArea(
+        child: Column(
+          children: [
+            Padding(
               padding: const EdgeInsets.symmetric(horizontal: S8llSpacing.lg, vertical: S8llSpacing.sm),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -256,7 +238,7 @@ class _FeedScreenState extends State<FeedScreen> {
                       Container(
                         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
                         decoration: BoxDecoration(
-                          color: S8llColors.charcoal.withValues(alpha: 0.85),
+                          color: S8llColors.charcoal,
                           borderRadius: BorderRadius.circular(999),
                         ),
                         child: Text(
@@ -274,9 +256,7 @@ class _FeedScreenState extends State<FeedScreen> {
                         child: Container(
                           padding: const EdgeInsets.all(8),
                           decoration: BoxDecoration(
-                            color: _hasActiveFilters
-                                ? S8llColors.lime
-                                : S8llColors.charcoal.withValues(alpha: 0.85),
+                            color: _hasActiveFilters ? S8llColors.lime : S8llColors.charcoal,
                             shape: BoxShape.circle,
                           ),
                           child: Icon(
@@ -291,15 +271,46 @@ class _FeedScreenState extends State<FeedScreen> {
                 ],
               ),
             ),
-          ),
-        ],
+            Expanded(
+              child: listings.isEmpty
+                  ? _EmptyFeed(hasFilters: _hasActiveFilters)
+                  : GridView.builder(
+                      padding: const EdgeInsets.fromLTRB(
+                        S8llSpacing.lg,
+                        S8llSpacing.xs,
+                        S8llSpacing.lg,
+                        S8llSpacing.lg,
+                      ),
+                      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: 2,
+                        mainAxisSpacing: S8llSpacing.md,
+                        crossAxisSpacing: S8llSpacing.md,
+                        childAspectRatio: 0.66,
+                      ),
+                      itemCount: listings.length,
+                      itemBuilder: (context, index) {
+                        final listing = listings[index];
+                        return _GridCard(
+                          listing: listing,
+                          onTap: () => Navigator.of(context).push(
+                            MaterialPageRoute(builder: (_) => ListingDetailScreen(listing: listing)),
+                          ),
+                        );
+                      },
+                    ),
+            ),
+          ],
+        ),
       ),
     );
   }
 }
 
-class _DropCard extends StatelessWidget {
-  const _DropCard({required this.listing, required this.onTap});
+/// One card in the feed grid: bounded photo up top with a small
+/// countdown/sold badge overlaid, real price/title/seller info below on a
+/// charcoal chip background so cards read distinctly against the black page.
+class _GridCard extends StatelessWidget {
+  const _GridCard({required this.listing, required this.onTap});
 
   final Listing listing;
   final VoidCallback onTap;
@@ -308,71 +319,66 @@ class _DropCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: onTap,
-      child: Stack(
-        fit: StackFit.expand,
-        children: [
-          _FullBleedPhoto(url: listing.photoUrl),
-          DecoratedBox(
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topCenter,
-                end: Alignment.bottomCenter,
-                stops: const [0.5, 1],
-                colors: [Colors.transparent, Colors.black.withValues(alpha: 0.85)],
+      child: Container(
+        clipBehavior: Clip.antiAlias,
+        decoration: BoxDecoration(
+          color: S8llColors.charcoal,
+          borderRadius: BorderRadius.circular(S8llRadius.md),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  _FullBleedPhoto(url: listing.photoUrl),
+                  Positioned(
+                    top: 8,
+                    right: 8,
+                    child: listing.status == ListingStatus.sold
+                        ? const _SoldBadge(compact: true)
+                        : _PulsingCountdown(listing: listing, compact: true),
+                  ),
+                ],
               ),
             ),
-          ),
-          if (listing.status == ListingStatus.sold)
-            const Positioned(
-              top: 96,
-              left: 20,
-              child: _SoldBadge(),
-            )
-          else
-            Positioned(
-              top: 96,
-              left: 20,
-              child: _PulsingCountdown(listing: listing),
-            ),
-          Positioned(
-            left: 20,
-            right: 20,
-            // RootShell's camera FAB floats centerFloat — its footprint is
-            // ~72px above the bottom nav bar (16 margin + 56 FAB height).
-            // bottom: 28 used to put this block's lower half directly
-            // behind it, invisible under an opaque button.
-            bottom: 80,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  listing.watcherCount > 0
-                      ? '${listing.sellerName} · ${listing.watcherCount} watching'
-                      : listing.sellerName,
-                  style: const TextStyle(color: Colors.white70, fontSize: 13),
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  '£${listing.priceInPounds.toStringAsFixed(0)}',
-                  style: const TextStyle(
-                    color: S8llColors.lime,
-                    fontWeight: FontWeight.w900,
-                    fontSize: 44,
-                    height: 1.0,
+            Padding(
+              padding: const EdgeInsets.all(S8llSpacing.sm),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    '£${listing.priceInPounds.toStringAsFixed(0)}',
+                    style: const TextStyle(
+                      color: S8llColors.lime,
+                      fontWeight: FontWeight.w900,
+                      fontSize: 20,
+                      height: 1.0,
+                    ),
                   ),
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  listing.title,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(color: Colors.white, fontSize: 17, fontWeight: FontWeight.w600),
-                ),
-              ],
+                  const SizedBox(height: 3),
+                  Text(
+                    listing.title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w600),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    listing.watcherCount > 0
+                        ? '${listing.sellerName} · ${listing.watcherCount} watching'
+                        : listing.sellerName,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(color: Colors.white54, fontSize: 11),
+                  ),
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -418,9 +424,10 @@ class _FullBleedPhoto extends StatelessWidget {
 /// elsewhere in the app. The pulse is decoration; the number is real —
 /// there's no per-second countdown to show, so this never claims one.
 class _PulsingCountdown extends StatefulWidget {
-  const _PulsingCountdown({required this.listing});
+  const _PulsingCountdown({required this.listing, this.compact = false});
 
   final Listing listing;
+  final bool compact;
 
   @override
   State<_PulsingCountdown> createState() => _PulsingCountdownState();
@@ -458,23 +465,28 @@ class _PulsingCountdownState extends State<_PulsingCountdown> with SingleTickerP
     return ScaleTransition(
       scale: _scale,
       child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        padding: EdgeInsets.symmetric(
+          horizontal: widget.compact ? 8 : 14,
+          vertical: widget.compact ? 4 : 8,
+        ),
         decoration: BoxDecoration(
           color: expiring ? Colors.redAccent : S8llColors.lime,
           borderRadius: BorderRadius.circular(999),
-          boxShadow: [
-            BoxShadow(
-              color: (expiring ? Colors.redAccent : S8llColors.lime).withValues(alpha: 0.5),
-              blurRadius: 16,
-            ),
-          ],
+          boxShadow: widget.compact
+              ? null
+              : [
+                  BoxShadow(
+                    color: (expiring ? Colors.redAccent : S8llColors.lime).withValues(alpha: 0.5),
+                    blurRadius: 16,
+                  ),
+                ],
         ),
         child: Text(
           label,
           style: TextStyle(
             color: expiring ? Colors.white : S8llColors.black,
             fontWeight: FontWeight.w800,
-            fontSize: 15,
+            fontSize: widget.compact ? 11 : 15,
           ),
         ),
       ),
@@ -483,16 +495,23 @@ class _PulsingCountdownState extends State<_PulsingCountdown> with SingleTickerP
 }
 
 class _SoldBadge extends StatelessWidget {
-  const _SoldBadge();
+  const _SoldBadge({this.compact = false});
+
+  final bool compact;
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      padding: EdgeInsets.symmetric(horizontal: compact ? 8 : 14, vertical: compact ? 4 : 8),
       decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(999)),
-      child: const Text(
+      child: Text(
         'SOLD',
-        style: TextStyle(color: Colors.black, fontWeight: FontWeight.w800, fontSize: 15, letterSpacing: 1),
+        style: TextStyle(
+          color: Colors.black,
+          fontWeight: FontWeight.w800,
+          fontSize: compact ? 11 : 15,
+          letterSpacing: 1,
+        ),
       ),
     );
   }

--- a/app/lib/services/demo_data.dart
+++ b/app/lib/services/demo_data.dart
@@ -1,0 +1,99 @@
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../models.dart';
+import 'auth_service.dart';
+import 'listings_repository.dart';
+
+/// A fixed demo account: same email/password every time, so "Try a demo
+/// account" signs into the *same* account (and whatever it's already
+/// seeded) on repeat visits and on any device, rather than creating a new
+/// throwaway user each time.
+class DemoAccount {
+  const DemoAccount({
+    required this.email,
+    required this.password,
+    required this.displayName,
+    required this.city,
+  });
+
+  final String email;
+  final String password;
+  final String displayName;
+  final String city;
+}
+
+const demoAccounts = <DemoAccount>[
+  DemoAccount(email: 'demo.alex@s8ll.app', password: 'S8llDemo1!', displayName: 'Alex', city: 'Manchester'),
+  DemoAccount(email: 'demo.sam@s8ll.app', password: 'S8llDemo1!', displayName: 'Sam', city: 'Manchester'),
+  DemoAccount(email: 'demo.jordan@s8ll.app', password: 'S8llDemo1!', displayName: 'Jordan', city: 'Manchester'),
+];
+
+class _DemoListing {
+  const _DemoListing(this.title, this.priceCents, this.category, this.delivery, this.photoSeed);
+
+  final String title;
+  final int priceCents;
+  final ListingCategory category;
+  final DeliveryMethod delivery;
+  final String photoSeed;
+}
+
+// Spread across the demo sellers so there's something real for a second
+// demo account to watch, offer on, or chat about.
+const _demoListingsByAccount = <List<_DemoListing>>[
+  [
+    _DemoListing('Carbon road bike, 54cm', 32000, ListingCategory.sportsAndOutdoors, DeliveryMethod.meetup, 's8ll-bike'),
+    _DemoListing('PS5 + 2 controllers', 28000, ListingCategory.electronics, DeliveryMethod.both, 's8ll-ps5'),
+    _DemoListing('Leather jacket, size M', 6500, ListingCategory.clothing, DeliveryMethod.shipping, 's8ll-jacket'),
+  ],
+  [
+    _DemoListing('IKEA 2-seater sofa', 12000, ListingCategory.home, DeliveryMethod.meetup, 's8ll-sofa'),
+    _DemoListing('Nike Air Max 90, UK9', 4500, ListingCategory.clothing, DeliveryMethod.both, 's8ll-trainers'),
+    _DemoListing('Nintendo Switch OLED', 18000, ListingCategory.electronics, DeliveryMethod.shipping, 's8ll-switch'),
+  ],
+  [
+    _DemoListing('Lego Millennium Falcon', 22000, ListingCategory.toysAndGames, DeliveryMethod.shipping, 's8ll-lego'),
+    _DemoListing('Standing desk, electric', 15000, ListingCategory.home, DeliveryMethod.meetup, 's8ll-desk'),
+    _DemoListing('Canon DSLR + 2 lenses', 35000, ListingCategory.electronics, DeliveryMethod.both, 's8ll-camera'),
+  ],
+];
+
+String _demoPhotoUrl(String seed) => 'https://picsum.photos/seed/$seed/900/1200';
+
+/// Signs into demo account [index] — creating it on first use anywhere,
+/// signing straight in on every use after — then seeds its starter
+/// listings the very first time only (checked by whether it already has
+/// any listings, not a separate flag).
+Future<void> useDemoAccount(AuthServiceBase authService, int index, {ListingsRepository? repository}) async {
+  final account = demoAccounts[index];
+  try {
+    await authService.signIn(email: account.email, password: account.password);
+  } on FirebaseAuthException {
+    await authService.signUp(
+      email: account.email,
+      password: account.password,
+      displayName: account.displayName,
+      city: account.city,
+    );
+  }
+
+  final uid = FirebaseAuth.instance.currentUser?.uid;
+  if (uid == null) return;
+
+  final listings = repository ?? ListingsRepository();
+  final existing = await listings.listingsBySeller(uid).first;
+  if (existing.isNotEmpty) return;
+
+  for (final template in _demoListingsByAccount[index]) {
+    await listings.publishWithPhotoUrl(
+      sellerId: uid,
+      sellerName: account.displayName,
+      sellerCity: account.city,
+      title: template.title,
+      priceCents: template.priceCents,
+      delivery: template.delivery,
+      category: template.category,
+      photoUrl: _demoPhotoUrl(template.photoSeed),
+    );
+  }
+}

--- a/app/lib/services/listings_repository.dart
+++ b/app/lib/services/listings_repository.dart
@@ -68,6 +68,36 @@ class ListingsRepository {
     await _listings.add(listing.toCreateMap());
   }
 
+  /// Same create path as [publish], but for a listing that already has a
+  /// hosted photo URL (demo/seed data) instead of a local camera file to
+  /// upload to Storage.
+  Future<void> publishWithPhotoUrl({
+    required String sellerId,
+    required String sellerName,
+    required String sellerCity,
+    required String title,
+    required int priceCents,
+    required DeliveryMethod delivery,
+    required String photoUrl,
+    String description = '',
+    ListingCategory category = ListingCategory.other,
+  }) {
+    final listing = Listing(
+      id: '', // assigned by Firestore
+      sellerId: sellerId,
+      sellerName: sellerName,
+      sellerCity: sellerCity,
+      title: title,
+      priceCents: priceCents,
+      delivery: delivery,
+      postedAt: DateTime.now(),
+      description: description,
+      photoUrl: photoUrl,
+      category: category,
+    );
+    return _listings.add(listing.toCreateMap());
+  }
+
   /// Re-lists an item at the top of the feed by resetting its post time.
   Future<void> bump(String listingId) {
     return _listings.doc(listingId).update({


### PR DESCRIPTION
## Summary
- Replace the one-listing-at-a-time full-screen swipe feed with a scrollable 2-column grid (`GridView`) so multiple live listings are visible at once, per direct visual reference the user provided.
- All real data stays: photo, price, title, seller/city, watcher count, and the real countdown/sold badge — just laid out in a compact card instead of full-bleed. Search/category/price filtering and saved searches are unchanged.
- Add three fixed demo accounts (`demo.alex@s8ll.app`, `demo.sam@s8ll.app`, `demo.jordan@s8ll.app`), reachable from the sign-in screen, so anyone testing the APK can jump into a populated app without creating a real account. Each seeds a handful of starter listings across categories the first time it's used (split across the three so there's something real to watch/offer/chat about between them).

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 32 tests pass
- [ ] CI (rules tests, functions build/test, Flutter analyze/test/build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195suo1jDY8EYgt9qC2apSs

---
_Generated by [Claude Code](https://claude.ai/code/session_0195suo1jDY8EYgt9qC2apSs)_