### PR TITLE
Fix permission-denied crash opening any other seller's listing

### DIFF
--- a/firestore-tests/src/firestore.rules.test.ts
+++ b/firestore-tests/src/firestore.rules.test.ts
@@ -531,4 +531,15 @@ describe("offers/{offerId}", () => {
     await assertSucceeds(dbAs(ALICE).doc(`offers/${OFFER}`).get());
     await assertFails(dbAs(CAROL).doc(`offers/${OFFER}`).get());
   });
+
+  it("lets anyone read an offer that doesn't exist yet, instead of erroring on the null resource", async () => {
+    // The app checks for its own not-yet-made offer on every listing it
+    // views (offers_repository.dart's offerFor), so this doc very often
+    // doesn't exist. A rule that dereferences resource.data without first
+    // checking existence fails this read with permission-denied rather
+    // than a clean "not found" — this is the regression that crashed
+    // opening any other seller's listing.
+    await assertSucceeds(dbAs(BOB).doc(`offers/${OFFER}`).get());
+    await assertSucceeds(dbAs(CAROL).doc(`offers/${OFFER}`).get());
+  });
 });

--- a/firestore.rules
+++ b/firestore.rules
@@ -119,8 +119,17 @@ service cloud.firestore {
     // classified as an update and falls through to the rule below, which
     // only the seller (not the buyer) can use.
     match /offers/{offerId} {
+      // A buyer viewing a listing they haven't offered on yet reads this
+      // doc before it exists — resource is then null, and referencing
+      // resource.data on a null resource is a rules evaluation error that
+      // Firestore reports as permission-denied, crashing the read. The
+      // exists() check short-circuits before that dereference ever
+      // happens; reading a document that isn't there can't leak anything,
+      // so it's safe to allow.
       allow read: if request.auth != null
-        && (request.auth.uid == resource.data.buyerId || request.auth.uid == resource.data.sellerId);
+        && (!exists(/databases/$(database)/documents/offers/$(offerId))
+            || request.auth.uid == resource.data.buyerId
+            || request.auth.uid == resource.data.sellerId);
       allow create: if request.auth != null
         && request.auth.uid == request.resource.data.buyerId
         && offerId == request.resource.data.listingId + '_' + request.resource.data.buyerId


### PR DESCRIPTION
## Summary
- Root cause: the `offers/{offerId}` Firestore rule's `allow read` unconditionally dereferenced `resource.data.buyerId`. `listing_detail_screen.dart` checks for the current viewer's own not-yet-made offer on every listing it opens (`offers_repository.dart`'s `offerFor`), so that document usually doesn't exist yet. When it doesn't, `resource` is `null`, and referencing `resource.data` on a null resource is a rules evaluation error — Firestore reports that back to the client as `permission-denied` rather than an empty read, crashing the screen.
- This reproduces on **any** live listing that isn't the viewer's own, before they've made an offer on it — matches the reported crash ("click on other lists", both on a demo account and a real one).
- Fix: short-circuit with `!exists(...)` before touching `resource.data`. Reading a document that doesn't exist can't leak anything, so it's safe to allow.
- Added a regression test (`firestore-tests/src/firestore.rules.test.ts`) covering a read of a not-yet-created offer doc by both the would-be buyer and an unrelated third party.

## Important: this needs a manual rules deploy
This is a `firestore.rules` change, and the CI workflow only tests rules — it doesn't deploy them. Merging this PR fixes the rule in the repo, but **the live crash won't stop until someone runs**:
```
firebase deploy --only firestore:rules
```
against the real project. I can't run this from this sandbox (no way to authenticate non-interactively here), so this needs to be run by hand after merge.

## Test plan
- [x] `firestore-tests` rules test suite against the emulator — all 64 tests pass (63 existing + 1 new)
- [ ] CI (rules tests, functions build/test, Flutter analyze/test/build)
- [ ] Manual `firebase deploy --only firestore:rules` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195suo1jDY8EYgt9qC2apSs

---
_Generated by [Claude Code](https://claude.ai/code/session_0195suo1jDY8EYgt9qC2apSs)_