### PR TITLE
Make the 8-hour expiry actually do something

### DIFF
--- a/app/lib/screens/feed_screen.dart
+++ b/app/lib/screens/feed_screen.dart
@@ -206,7 +206,12 @@ class _FeedScreenState extends State<FeedScreen> {
     final appState = context.watch<AppState>();
     final uid = appState.uid;
     final blocked = appState.profile?.blockedUserIds ?? const [];
-    final visible = appState.listings.where((l) => !blocked.contains(l.sellerId)).toList();
+    // Expiry first, then blocking, then the user's own search/category/price
+    // choices — so the "N live now" pill counts what's genuinely still live
+    // rather than every listing ever posted.
+    final visible = stillLive(appState.listings, now: DateTime.now())
+        .where((l) => !blocked.contains(l.sellerId))
+        .toList();
     final listings = filterListings(
       visible,
       query: _searchController.text,
@@ -332,7 +337,7 @@ class _GridCard extends StatelessWidget {
               child: Stack(
                 fit: StackFit.expand,
                 children: [
-                  _FullBleedPhoto(url: listing.photoUrl),
+                  _ListingPhoto(url: listing.photoUrl),
                   Positioned(
                     top: 8,
                     right: 8,
@@ -384,8 +389,8 @@ class _GridCard extends StatelessWidget {
   }
 }
 
-class _FullBleedPhoto extends StatelessWidget {
-  const _FullBleedPhoto({required this.url});
+class _ListingPhoto extends StatelessWidget {
+  const _ListingPhoto({required this.url});
 
   final String? url;
 

--- a/app/lib/services/demo_data.dart
+++ b/app/lib/services/demo_data.dart
@@ -60,10 +60,36 @@ const _demoListingsByAccount = <List<_DemoListing>>[
 
 String _demoPhotoUrl(String seed) => 'https://picsum.photos/seed/$seed/900/1200';
 
+/// What a demo account needs on sign-in to have something live to show.
+enum DemoSeedAction {
+  /// Its listings are still within their window — leave them alone.
+  none,
+
+  /// It has listings, but every one of them has timed out. Bumping resets
+  /// `postedAt`, which is all expiry is measured from, so they come back
+  /// without piling up duplicates in Firestore every time someone demos.
+  bumpExpired,
+
+  /// Nothing live to bump — first ever use, or everything since sold.
+  seedStarterListings,
+}
+
+/// Decides what [useDemoAccount] should do, given what the account already
+/// owns. Pure and clock-injected so the rule is testable without Firebase.
+///
+/// The 8-hour window is the point: seeding only when a demo account has
+/// *zero* listings leaves it looking permanently empty the morning after
+/// someone first tries it — which is exactly when it gets demoed.
+DemoSeedAction demoSeedActionFor(List<Listing> mine, DateTime now) {
+  final live = mine.where((l) => l.status == ListingStatus.live);
+  if (live.any((l) => !l.isExpired(now))) return DemoSeedAction.none;
+  if (live.isNotEmpty) return DemoSeedAction.bumpExpired;
+  return DemoSeedAction.seedStarterListings;
+}
+
 /// Signs into demo account [index] — creating it on first use anywhere,
-/// signing straight in on every use after — then seeds its starter
-/// listings the very first time only (checked by whether it already has
-/// any listings, not a separate flag).
+/// signing straight in on every use after — then makes sure it has
+/// something live to show, per [demoSeedActionFor].
 Future<void> useDemoAccount(AuthServiceBase authService, int index, {ListingsRepository? repository}) async {
   final account = demoAccounts[index];
   try {
@@ -81,19 +107,27 @@ Future<void> useDemoAccount(AuthServiceBase authService, int index, {ListingsRep
   if (uid == null) return;
 
   final listings = repository ?? ListingsRepository();
-  final existing = await listings.listingsBySeller(uid).first;
-  if (existing.isNotEmpty) return;
+  final mine = await listings.listingsBySeller(uid).first;
 
-  for (final template in _demoListingsByAccount[index]) {
-    await listings.publishWithPhotoUrl(
-      sellerId: uid,
-      sellerName: account.displayName,
-      sellerCity: account.city,
-      title: template.title,
-      priceCents: template.priceCents,
-      delivery: template.delivery,
-      category: template.category,
-      photoUrl: _demoPhotoUrl(template.photoSeed),
-    );
+  switch (demoSeedActionFor(mine, DateTime.now())) {
+    case DemoSeedAction.none:
+      return;
+    case DemoSeedAction.bumpExpired:
+      for (final listing in mine.where((l) => l.status == ListingStatus.live)) {
+        await listings.bump(listing.id);
+      }
+    case DemoSeedAction.seedStarterListings:
+      for (final template in _demoListingsByAccount[index]) {
+        await listings.publishWithPhotoUrl(
+          sellerId: uid,
+          sellerName: account.displayName,
+          sellerCity: account.city,
+          title: template.title,
+          priceCents: template.priceCents,
+          delivery: template.delivery,
+          category: template.category,
+          photoUrl: _demoPhotoUrl(template.photoSeed),
+        );
+      }
   }
 }

--- a/app/lib/services/listing_filter.dart
+++ b/app/lib/services/listing_filter.dart
@@ -1,5 +1,20 @@
 import '../models.dart';
 
+/// Drops listings whose 8-hour window has run out.
+///
+/// A listing's `status` field only ever moves to `sold` (by the payment
+/// webhook) — nothing anywhere flips it when the timer runs out, so
+/// `listings` still carries every expired drop it ever streamed. Expiry is
+/// therefore purely a function of `postedAt + liveFor`, evaluated here at
+/// read time rather than stored. Without this the whole 8-hour mechanic is
+/// decorative: dead listings sit in the feed forever showing "Expired", and
+/// they're counted in the "N live now" pill.
+///
+/// [now] is injected rather than read from the clock so this stays testable.
+List<Listing> stillLive(List<Listing> listings, {required DateTime now}) {
+  return listings.where((listing) => !listing.isExpired(now)).toList();
+}
+
 /// Pure client-side filtering over an already-loaded listings list — no new
 /// Firestore query/index needed, since AppState already streams every live
 /// listing into memory for the feed.

--- a/app/test/demo_data_test.dart
+++ b/app/test/demo_data_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s8ll/models.dart';
+import 'package:s8ll/services/demo_data.dart';
+
+Listing _listing({
+  required String id,
+  required DateTime postedAt,
+  ListingStatus status = ListingStatus.live,
+}) {
+  return Listing(
+    id: id,
+    sellerId: 'demo-seller',
+    sellerName: 'Alex',
+    sellerCity: 'Manchester',
+    title: 'Demo item',
+    priceCents: 1000,
+    delivery: DeliveryMethod.both,
+    postedAt: postedAt,
+    status: status,
+  );
+}
+
+void main() {
+  final now = DateTime(2026, 1, 1, 12);
+
+  group('demoSeedActionFor', () {
+    test('seeds the starter set for an account that has never listed', () {
+      expect(demoSeedActionFor([], now), DemoSeedAction.seedStarterListings);
+    });
+
+    test('leaves an account alone while any listing is still within its window', () {
+      final mine = [
+        _listing(id: 'a', postedAt: now.subtract(const Duration(hours: 9))),
+        _listing(id: 'b', postedAt: now.subtract(const Duration(hours: 1))),
+      ];
+      expect(demoSeedActionFor(mine, now), DemoSeedAction.none);
+    });
+
+    test('bumps rather than reseeds when every listing has timed out', () {
+      // The point of bumping: demoing on day two must not pile up a fresh
+      // copy of the starter set in Firestore every single time.
+      final mine = [
+        _listing(id: 'a', postedAt: now.subtract(const Duration(hours: 9))),
+        _listing(id: 'b', postedAt: now.subtract(const Duration(hours: 30))),
+      ];
+      expect(demoSeedActionFor(mine, now), DemoSeedAction.bumpExpired);
+    });
+
+    test('seeds again when everything it ever listed has sold', () {
+      // Sold listings can't be bumped back to life — status never returns
+      // to live — so there'd be nothing to show without a fresh set.
+      final mine = [
+        _listing(
+          id: 'a',
+          postedAt: now.subtract(const Duration(hours: 2)),
+          status: ListingStatus.sold,
+        ),
+      ];
+      expect(demoSeedActionFor(mine, now), DemoSeedAction.seedStarterListings);
+    });
+
+    test('ignores sold listings when deciding whether anything is still live', () {
+      final mine = [
+        _listing(
+          id: 'sold-but-recent',
+          postedAt: now.subtract(const Duration(hours: 1)),
+          status: ListingStatus.sold,
+        ),
+        _listing(id: 'expired', postedAt: now.subtract(const Duration(hours: 9))),
+      ];
+      expect(demoSeedActionFor(mine, now), DemoSeedAction.bumpExpired);
+    });
+  });
+
+  test('every demo account has a distinct sign-in', () {
+    final emails = demoAccounts.map((a) => a.email).toSet();
+    expect(emails.length, demoAccounts.length);
+  });
+}

--- a/app/test/listing_filter_test.dart
+++ b/app/test/listing_filter_test.dart
@@ -7,6 +7,8 @@ Listing _listing({
   required String title,
   required int priceCents,
   ListingCategory category = ListingCategory.other,
+  DateTime? postedAt,
+  Duration? liveFor,
 }) {
   return Listing(
     id: id,
@@ -16,8 +18,9 @@ Listing _listing({
     title: title,
     priceCents: priceCents,
     delivery: DeliveryMethod.both,
-    postedAt: DateTime.now(),
+    postedAt: postedAt ?? DateTime.now(),
     category: category,
+    liveFor: liveFor,
   );
 }
 
@@ -55,5 +58,53 @@ void main() {
       maxPriceCents: 2500,
     );
     expect(result.map((l) => l.id), ['l3']);
+  });
+
+  group('stillLive', () {
+    final now = DateTime(2026, 1, 1, 12);
+
+    test('keeps a listing whose window is still open', () {
+      final fresh = _listing(
+        id: 'fresh',
+        title: 'Fresh drop',
+        priceCents: 1000,
+        postedAt: now.subtract(const Duration(hours: 7)),
+      );
+      expect(stillLive([fresh], now: now).map((l) => l.id), ['fresh']);
+    });
+
+    test('drops a listing whose 8 hours have run out', () {
+      // Nothing ever flips `status` when the timer ends, so an expired
+      // listing keeps streaming in from Firestore forever — this is the
+      // only thing keeping it out of the feed.
+      final dead = _listing(
+        id: 'dead',
+        title: 'Yesterday',
+        priceCents: 1000,
+        postedAt: now.subtract(const Duration(hours: 9)),
+      );
+      expect(stillLive([dead], now: now), isEmpty);
+    });
+
+    test('drops a listing exactly at its expiry instant', () {
+      final onTheLine = _listing(
+        id: 'edge',
+        title: 'On the line',
+        priceCents: 1000,
+        postedAt: now.subtract(const Duration(hours: 8)),
+      );
+      expect(stillLive([onTheLine], now: now), isEmpty);
+    });
+
+    test('honours a non-default liveFor rather than assuming 8 hours', () {
+      final shortDrop = _listing(
+        id: 'short',
+        title: 'Quick one',
+        priceCents: 1000,
+        postedAt: now.subtract(const Duration(hours: 2)),
+        liveFor: const Duration(hours: 1),
+      );
+      expect(stillLive([shortDrop], now: now), isEmpty);
+    });
   });
 }


### PR DESCRIPTION
## Summary
Review pass over the recently shipped grid feed and demo accounts. Found two real bugs, both from the same root cause: **nothing ever marks a listing expired.**

`status` only ever moves to `sold`, and the payment webhook is what does it — no client and no Cloud Function flips anything when a drop's timer runs out. `Listing.isExpired()` existed but was never called anywhere in the app.

**Bug 1 — expired listings never leave the feed.** They kept streaming in forever, showing "Expired" under the photo, and were counted in the "N live now" pill. The 8-hour mechanic was decorative. Expiry is now evaluated at read time (`postedAt + liveFor` vs now) in a `stillLive()` helper, applied ahead of blocking and the user's search/category/price filters, so the pill counts what's genuinely live.

**Bug 2 — demo accounts go stale after 8 hours.** `useDemoAccount` only seeded when an account had *zero* listings. The morning after anyone first tried one, its starter listings were expired, the account still "had listings", so nothing reseeded — and with Bug 1 fixed it would have shown an empty feed, exactly when it'd be demoed. It now bumps expired listings back into the window instead (resets `postedAt`, so no duplicate piles accumulate in Firestore), and only reseeds when there's genuinely nothing live to bump — e.g. after everything sold. The decision is a pure function (`demoSeedActionFor`) so it's testable without Firebase.

Also renames `_FullBleedPhoto` → `_ListingPhoto`; it's been inside a bounded grid card since the feed stopped being full-screen.

## Deliberately not included
- **Expired listings are still purchasable** if reached directly (a watched item, a deep link) — `canBuyInApp` checks `status` and delivery method, not the timer. Fixing that changes Stripe checkout eligibility, so it wants its own PR and a decision from you rather than being folded in silently.
- A "clean up expired listings" scheduled function. Read-time expiry is enough for correctness; a sweeper is an optimisation for when the collection gets big.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 42 pass (was 32); 10 new covering the expiry boundary, a non-default `liveFor`, and each demo-reseed branch
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195suo1jDY8EYgt9qC2apSs

---
_Generated by [Claude Code](https://claude.ai/code/session_0195suo1jDY8EYgt9qC2apSs)_