### PR TITLE
Restyle listing, chat, profile and publish to match the prototype

### DIFF
--- a/app/lib/screens/chat_screen.dart
+++ b/app/lib/screens/chat_screen.dart
@@ -29,6 +29,15 @@ class _ChatScreenState extends State<ChatScreen> {
     super.dispose();
   }
 
+  /// 24-hour clock, zero-padded. Written out rather than pulled from
+  /// `intl` — the app doesn't depend on it, and this is the only place
+  /// that formats a time.
+  String _timeLabel(DateTime sentAt) {
+    final hour = sentAt.hour.toString().padLeft(2, '0');
+    final minute = sentAt.minute.toString().padLeft(2, '0');
+    return '$hour:$minute';
+  }
+
   void _send(Listing listing, String senderName, String senderId) {
     if (_controller.text.trim().isEmpty) return;
     context.read<ChatRepository>().sendMessage(
@@ -65,7 +74,49 @@ class _ChatScreenState extends State<ChatScreen> {
             context.watch<AppState>().profile?.displayName ?? 'S8LL user';
 
         return Scaffold(
-          appBar: AppBar(title: Text(otherName)),
+          appBar: AppBar(
+            titleSpacing: 0,
+            title: Row(
+              children: [
+                // An initial, not a photo — profiles carry no avatar, and
+                // the prototype's "online • responds fast" line has no
+                // presence data behind it, so neither is drawn.
+                CircleAvatar(
+                  radius: 16,
+                  backgroundColor: S8llColors.limeSoft,
+                  child: Text(
+                    otherName.isEmpty ? '?' : otherName[0].toUpperCase(),
+                    style: const TextStyle(
+                      color: S8llColors.lime,
+                      fontWeight: FontWeight.w800,
+                      fontSize: 14,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        otherName,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+                      ),
+                      Text(
+                        listing.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(fontSize: 12, color: context.s8ll.textSecondary),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
           body: Column(
             children: [
               Expanded(
@@ -91,18 +142,51 @@ class _ChatScreenState extends State<ChatScreen> {
                           alignment:
                               fromSelf ? Alignment.centerRight : Alignment.centerLeft,
                           child: Container(
-                            margin: const EdgeInsets.symmetric(vertical: 4),
+                            margin: const EdgeInsets.only(bottom: 10),
                             padding:
                                 const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                            constraints: BoxConstraints(
+                              maxWidth: MediaQuery.of(context).size.width * 0.75,
+                            ),
                             decoration: BoxDecoration(
                               color: fromSelf ? S8llColors.lime : context.s8ll.surfaceHigh,
-                              borderRadius: BorderRadius.circular(16),
-                            ),
-                            child: Text(
-                              message.text,
-                              style: TextStyle(
-                                color: fromSelf ? S8llColors.black : context.s8ll.textPrimary,
+                              // Square off the corner nearest the sender so
+                              // each bubble points back at whoever wrote it.
+                              borderRadius: BorderRadius.only(
+                                topLeft: const Radius.circular(18),
+                                topRight: const Radius.circular(18),
+                                bottomLeft: Radius.circular(fromSelf ? 18 : 4),
+                                bottomRight: Radius.circular(fromSelf ? 4 : 18),
                               ),
+                            ),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.end,
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  message.text,
+                                  style: TextStyle(
+                                    height: 1.3,
+                                    fontSize: 15,
+                                    color: fromSelf
+                                        ? S8llColors.black
+                                        : context.s8ll.textPrimary,
+                                  ),
+                                ),
+                                const SizedBox(height: 3),
+                                // Real send time off the message document.
+                                // No read receipts here — nothing records
+                                // whether the other side has seen it.
+                                Text(
+                                  _timeLabel(message.sentAt),
+                                  style: TextStyle(
+                                    fontSize: 11,
+                                    color: fromSelf
+                                        ? S8llColors.black.withValues(alpha: 0.6)
+                                        : context.s8ll.textTertiary,
+                                  ),
+                                ),
+                              ],
                             ),
                           ),
                         );
@@ -119,14 +203,43 @@ class _ChatScreenState extends State<ChatScreen> {
                       Expanded(
                         child: TextField(
                           controller: _controller,
-                          decoration: const InputDecoration(hintText: 'Message'),
+                          textCapitalization: TextCapitalization.sentences,
+                          decoration: InputDecoration(
+                            hintText: 'Message',
+                            filled: true,
+                            fillColor: context.s8ll.surfaceHigh,
+                            contentPadding: const EdgeInsets.symmetric(
+                              horizontal: S8llSpacing.lg,
+                              vertical: 12,
+                            ),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(S8llRadius.pill),
+                              borderSide: BorderSide.none,
+                            ),
+                            enabledBorder: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(S8llRadius.pill),
+                              borderSide: BorderSide.none,
+                            ),
+                            focusedBorder: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(S8llRadius.pill),
+                              borderSide: const BorderSide(color: S8llColors.lime),
+                            ),
+                          ),
                           onSubmitted: (_) => _send(listing, selfName, uid),
                         ),
                       ),
-                      const SizedBox(width: 8),
-                      IconButton.filled(
-                        onPressed: () => _send(listing, selfName, uid),
-                        icon: const Icon(Icons.send),
+                      const SizedBox(width: S8llSpacing.sm),
+                      Material(
+                        color: S8llColors.lime,
+                        shape: const CircleBorder(),
+                        child: InkWell(
+                          customBorder: const CircleBorder(),
+                          onTap: () => _send(listing, selfName, uid),
+                          child: const Padding(
+                            padding: EdgeInsets.all(12),
+                            child: Icon(Icons.arrow_upward, color: S8llColors.black, size: 20),
+                          ),
+                        ),
                       ),
                     ],
                   ),

--- a/app/lib/screens/listing_detail_screen.dart
+++ b/app/lib/screens/listing_detail_screen.dart
@@ -377,6 +377,15 @@ class _ListingDetailScreenState extends State<ListingDetailScreen> {
   // No s8ll.com yet (SETUP.md flags this same gap for the Stripe return
   // URLs) — sharing the listing's real details is still useful on its
   // own, so this doesn't invent a link to a domain that isn't live.
+  /// Same wording as [CountdownBadge] uses, at the larger size the page
+  /// header wants. Real remaining time — there's no per-second tick behind
+  /// it, so it never pretends to be a live clock.
+  String _remainingLabel(Duration remaining) {
+    if (remaining == Duration.zero) return 'Expired';
+    if (remaining.inHours >= 1) return '${remaining.inHours}h left';
+    return '${remaining.inMinutes}m left';
+  }
+
   void _share() {
     final listing = widget.listing;
     final remaining = listing.remaining(DateTime.now());
@@ -404,8 +413,27 @@ class _ListingDetailScreenState extends State<ListingDetailScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(listing.title),
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        // The wordmark rather than the listing title: the title now leads
+        // the page body at full size, so repeating it here just competed
+        // with itself.
+        title: const Text(
+          'S8LL',
+          style: TextStyle(
+            color: S8llColors.lime,
+            fontWeight: FontWeight.w900,
+            fontSize: 22,
+            letterSpacing: -0.5,
+          ),
+        ),
         actions: [
+          IconButton(
+            icon: Icon(_watching ? Icons.favorite : Icons.favorite_border),
+            color: _watching ? S8llColors.lime : null,
+            tooltip: _watching ? 'Stop watching' : 'Watch',
+            onPressed: _toggleWatch,
+          ),
           IconButton(
             icon: const Icon(Icons.share_outlined),
             tooltip: 'Share',
@@ -432,63 +460,137 @@ class _ListingDetailScreenState extends State<ListingDetailScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Stack(
-              children: [
-                ListingPhoto(photoUrl: listing.photoUrl, height: 320),
-                Positioned(
-                  top: 12,
-                  right: 12,
-                  child: isSold
-                      ? const _SoldBadge()
-                      : CountdownBadge(remaining: listing.remaining(DateTime.now())),
-                ),
-              ],
+            ClipRRect(
+              borderRadius: BorderRadius.circular(S8llRadius.lg),
+              child: Stack(
+                children: [
+                  ListingPhoto(photoUrl: listing.photoUrl, height: 320),
+                  Positioned(
+                    top: 12,
+                    right: 12,
+                    child: isSold
+                        ? const _SoldBadge()
+                        : CountdownBadge(remaining: listing.remaining(DateTime.now())),
+                  ),
+                ],
+              ),
             ),
-            const SizedBox(height: 16),
+            const SizedBox(height: 20),
+            // Title first, then the timer, then the price — the order the
+            // decision actually gets made in: what it is, how long you have,
+            // what it costs.
+            Text(
+              listing.title,
+              style: const TextStyle(fontSize: 28, fontWeight: FontWeight.w800, height: 1.15),
+            ),
+            const SizedBox(height: 12),
+            if (!isSold)
+              Row(
+                children: [
+                  const Icon(Icons.schedule, color: S8llColors.lime, size: 20),
+                  const SizedBox(width: 6),
+                  Text(
+                    _remainingLabel(listing.remaining(DateTime.now())),
+                    style: const TextStyle(
+                      color: S8llColors.lime,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
+              ),
+            const SizedBox(height: 12),
             Text(
               '£${listing.priceInPounds.toStringAsFixed(0)}',
               style: const TextStyle(
                 color: S8llColors.lime,
-                fontWeight: FontWeight.w800,
-                fontSize: 28,
+                fontWeight: FontWeight.w900,
+                fontSize: 52,
+                height: 1,
+                letterSpacing: -1.5,
               ),
             ),
-            const SizedBox(height: 4),
-            Text(listing.title, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w700)),
             const SizedBox(height: 8),
-            if (listing.description.isNotEmpty) Text(listing.description),
-            const SizedBox(height: 12),
-            Row(
+            Text(
+              listing.delivery.label,
+              style: TextStyle(color: context.s8ll.textSecondary, fontSize: 15),
+            ),
+            const SizedBox(height: 20),
+            Divider(color: context.s8ll.divider, height: 1),
+            const SizedBox(height: 20),
+            if (listing.description.isNotEmpty) ...[
+              Text('Details', style: Theme.of(context).textTheme.titleLarge),
+              const SizedBox(height: 10),
+              Text(
+                listing.description,
+                style: TextStyle(color: context.s8ll.textSecondary, height: 1.5, fontSize: 15),
+              ),
+              const SizedBox(height: 14),
+            ],
+            // Only facts the listing actually carries. The prototype also
+            // showed a "Condition" chip; there's no such field, so there's
+            // no chip.
+            Wrap(
+              spacing: S8llSpacing.sm,
+              runSpacing: S8llSpacing.sm,
               children: [
-                Icon(Icons.person_outline, size: 18, color: context.s8ll.textSecondary),
-                const SizedBox(width: 6),
-                Text('${listing.sellerName} · ${listing.sellerCity}',
-                    style: TextStyle(color: context.s8ll.textSecondary)),
+                _DetailChip(label: 'Category', value: listing.category.label),
+                _DetailChip(label: 'Delivery', value: listing.delivery.label),
+                if (_watcherCount > 0)
+                  _DetailChip(
+                    label: 'Watching',
+                    value: _watcherCount == 1 ? '1 person' : '$_watcherCount people',
+                  ),
               ],
             ),
-            const SizedBox(height: 4),
-            SellerRatingBadge(rating: _sellerRating),
-            const SizedBox(height: 6),
-            Row(
-              children: [
-                Icon(Icons.local_shipping_outlined, size: 18, color: context.s8ll.textSecondary),
-                const SizedBox(width: 6),
-                Text(listing.delivery.label, style: TextStyle(color: context.s8ll.textSecondary)),
-              ],
-            ),
-            if (_watcherCount > 0) ...[
-              const SizedBox(height: 6),
-              Row(
+            const SizedBox(height: 20),
+            Divider(color: context.s8ll.divider, height: 1),
+            const SizedBox(height: 20),
+            Container(
+              padding: const EdgeInsets.all(S8llSpacing.lg),
+              decoration: BoxDecoration(
+                color: context.s8ll.surface,
+                borderRadius: BorderRadius.circular(S8llRadius.md),
+              ),
+              child: Row(
                 children: [
-                  Icon(Icons.visibility_outlined, size: 18, color: context.s8ll.textSecondary),
-                  const SizedBox(width: 6),
-                  Text(
-                    _watcherCount == 1 ? '1 person watching' : '$_watcherCount people watching',
-                    style: TextStyle(color: context.s8ll.textSecondary),
+                  // An initial, not a photo: there's no avatar field on a
+                  // profile, and inventing one would mean showing a face
+                  // that isn't the seller's.
+                  CircleAvatar(
+                    radius: 22,
+                    backgroundColor: S8llColors.limeSoft,
+                    child: Text(
+                      listing.sellerName.isEmpty ? '?' : listing.sellerName[0].toUpperCase(),
+                      style: const TextStyle(
+                        color: S8llColors.lime,
+                        fontWeight: FontWeight.w800,
+                        fontSize: 18,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 14),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          listing.sellerName,
+                          style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 16),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          listing.sellerCity,
+                          style: TextStyle(color: context.s8ll.textSecondary, fontSize: 13),
+                        ),
+                        const SizedBox(height: 6),
+                        SellerRatingBadge(rating: _sellerRating),
+                      ],
+                    ),
                   ),
                 ],
               ),
-            ],
+            ),
             const SizedBox(height: 24),
             if (isSold) ...[
               Text('This item has sold.', style: TextStyle(color: context.s8ll.textSecondary)),
@@ -697,8 +799,44 @@ class _ListingDetailScreenState extends State<ListingDetailScreen> {
   }
 }
 
+/// A labelled fact about the listing — small caption over the value, on a
+/// raised surface. Only ever built from a field the listing really has.
+class _DetailChip extends StatelessWidget {
+  const _DetailChip({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      decoration: BoxDecoration(
+        color: context.s8ll.surface,
+        borderRadius: BorderRadius.circular(S8llRadius.sm),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            label,
+            style: TextStyle(fontSize: 11, color: context.s8ll.textTertiary),
+          ),
+          const SizedBox(height: 1),
+          Text(
+            value,
+            style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _SoldBadge extends StatelessWidget {
   const _SoldBadge();
+
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/screens/profile_screen.dart
+++ b/app/lib/screens/profile_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../models.dart';
 import '../services/auth_service.dart';
 import '../services/payments_service.dart';
+import '../services/listing_filter.dart';
 import '../services/reviews_repository.dart';
 import '../state/app_state.dart';
 import '../state/theme_controller.dart';
@@ -58,8 +59,17 @@ class _ProfileScreenState extends State<ProfileScreen> {
               children: [
                 CircleAvatar(
                   radius: 32,
-                  backgroundColor: context.s8ll.surfaceHigh,
-                  child: const Icon(Icons.person, color: S8llColors.lime, size: 32),
+                  backgroundColor: S8llColors.limeSoft,
+                  child: Text(
+                    (profile?.displayName ?? '?').isEmpty
+                        ? '?'
+                        : (profile?.displayName ?? '?')[0].toUpperCase(),
+                    style: const TextStyle(
+                      color: S8llColors.lime,
+                      fontWeight: FontWeight.w900,
+                      fontSize: 26,
+                    ),
+                  ),
                 ),
                 const SizedBox(width: 16),
                 Expanded(
@@ -68,7 +78,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                     children: [
                       Text(
                         profile?.displayName ?? '…',
-                        style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w800),
+                        style: const TextStyle(fontSize: 22, fontWeight: FontWeight.w800),
                       ),
                       const SizedBox(height: 4),
                       Text(profile?.city ?? '', style: TextStyle(color: context.s8ll.textSecondary)),
@@ -80,6 +90,41 @@ class _ProfileScreenState extends State<ProfileScreen> {
               ],
             ),
           ),
+          // The prototype's stat row, built only from numbers the account
+          // really has. It showed "Assets £2,840", a follower count and a
+          // level; there is no wallet balance, no follow graph and no
+          // levelling here, so the three real equivalents stand in: how
+          // many of your listings are live right now, how many have sold,
+          // and how many people are watching across all of them.
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Container(
+              padding: const EdgeInsets.symmetric(vertical: S8llSpacing.lg),
+              decoration: BoxDecoration(
+                color: context.s8ll.surface,
+                borderRadius: BorderRadius.circular(S8llRadius.md),
+              ),
+              child: Row(
+                children: [
+                  _Stat(
+                    value: '${stillLive(myListings, now: DateTime.now()).length}',
+                    label: 'Live now',
+                  ),
+                  _StatDivider(),
+                  _Stat(
+                    value: '${myListings.where((l) => l.status == ListingStatus.sold).length}',
+                    label: 'Sold',
+                  ),
+                  _StatDivider(),
+                  _Stat(
+                    value: '${myListings.fold<int>(0, (sum, l) => sum + l.watcherCount)}',
+                    label: 'Watching',
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: S8llSpacing.md),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: _PayoutStatusCard(payoutsEnabled: profile?.payoutsEnabled ?? false),
@@ -131,6 +176,46 @@ class _ProfileScreenState extends State<ProfileScreen> {
         ],
       ),
     );
+  }
+}
+
+/// One figure in the profile's stat row. Value large in lime, caption
+/// under it — the prototype's treatment, carrying a real count.
+class _Stat extends StatelessWidget {
+  const _Stat({required this.value, required this.label});
+
+  final String value;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Column(
+        children: [
+          Text(
+            value,
+            style: const TextStyle(
+              color: S8llColors.lime,
+              fontWeight: FontWeight.w900,
+              fontSize: 22,
+              height: 1,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            label,
+            style: TextStyle(fontSize: 12, color: context.s8ll.textSecondary),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatDivider extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(width: 1, height: 28, color: context.s8ll.divider);
   }
 }
 

--- a/app/lib/screens/publish_screen.dart
+++ b/app/lib/screens/publish_screen.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 
 import '../models.dart';
 import '../state/app_state.dart';
+import '../theme.dart';
 import 'root_shell.dart';
 
 class PublishScreen extends StatefulWidget {
@@ -72,15 +73,41 @@ class _PublishScreenState extends State<PublishScreen> {
           child: ListView(
             children: [
               ClipRRect(
-                borderRadius: BorderRadius.circular(16),
-                child: Image.file(
-                  File(widget.photoPath),
-                  height: 260,
-                  width: double.infinity,
-                  fit: BoxFit.cover,
+                borderRadius: BorderRadius.circular(S8llRadius.lg),
+                child: Stack(
+                  children: [
+                    Image.file(
+                      File(widget.photoPath),
+                      height: 260,
+                      width: double.infinity,
+                      fit: BoxFit.cover,
+                    ),
+                    // Says the actual rule up front rather than after the
+                    // fact: publishing starts an 8-hour clock, and that's
+                    // the whole mechanic.
+                    Positioned(
+                      top: 12,
+                      left: 12,
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+                        decoration: BoxDecoration(
+                          color: S8llColors.lime,
+                          borderRadius: BorderRadius.circular(S8llRadius.pill),
+                        ),
+                        child: const Text(
+                          'Goes live for 8h',
+                          style: TextStyle(
+                            color: S8llColors.black,
+                            fontSize: 12,
+                            fontWeight: FontWeight.w800,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
-              const SizedBox(height: 16),
+              const SizedBox(height: 20),
               TextFormField(
                 controller: _titleController,
                 decoration: const InputDecoration(labelText: 'What is it?'),
@@ -89,7 +116,16 @@ class _PublishScreenState extends State<PublishScreen> {
               const SizedBox(height: 12),
               TextFormField(
                 controller: _priceController,
-                decoration: const InputDecoration(labelText: 'Price (£)'),
+                style: const TextStyle(fontSize: 24, fontWeight: FontWeight.w800),
+                decoration: const InputDecoration(
+                  labelText: 'Price',
+                  prefixText: '£ ',
+                  prefixStyle: TextStyle(
+                    color: S8llColors.lime,
+                    fontSize: 24,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
                 keyboardType: const TextInputType.numberWithOptions(decimal: true),
                 // Some keyboards (Samsung's included) insert a stray space
                 // after the decimal point under auto-punctuation, which

--- a/app/lib/theme.dart
+++ b/app/lib/theme.dart
@@ -136,6 +136,9 @@ class S8llSpacing {
 class S8llRadius {
   static const sm = 12.0;
   static const md = 16.0;
+  /// For the one or two surfaces big enough to carry it — a full-width hero
+  /// photo, mainly. At card size this much rounding eats the corners.
+  static const lg = 24.0;
   static const pill = 999.0;
 }
 


### PR DESCRIPTION
## Summary
Ports the uploaded prototype's design onto the four remaining real screens. **Presentation only** — buy, offer, watch, review, tracking, report/block, sending messages, publishing, payouts, theme switching and sign-out all behave exactly as before.

### Listing page
Layout follows the order the decision actually gets made in: title at 28/w800 → countdown beside a lime clock → price at 52/w900 → delivery method. Hero photo takes the prototype's 24px corners. Seller moves into a raised card with their real rating. Heart in the header is the same real watch toggle as the button below.

### Chat
Bubbles take the prototype's asymmetric corners — the one nearest the sender squared off so each points back at whoever wrote it — capped at 75% width, with the message's real `sentAt` inside. Header carries the other party plus the listing it's about. Composer becomes a pill field with a round send button.

### Profile
Gains the prototype's three-figure stat row, built only from counts the account really has:

| Prototype showed | This shows | Source |
|---|---|---|
| Assets £2,840 | **Live now** | own listings, unexpired |
| Followers 4.2K | **Sold** | own listings, `status == sold` |
| Lv.8 | **Watching** | sum of `watcherCount` |

There's no wallet balance, no follow graph and no levelling, so those three stand in. Avatar becomes the seller's initial rather than a generic person glyph.

### Publish
Photo picks up the same 24px corners and carries a **"Goes live for 8h"** pill — stating the actual rule at the moment it applies, rather than leaving it to be discovered. Price gets a lime £ prefix at display size.

## Deliberately not built
- **Condition chip, seller avatar photos, "online · replies fast", read receipts** — no field, no presence tracking, no read tracking. An initial stands in for an avatar rather than showing a face that isn't theirs.
- **Dewu authentication toggle, 9-photo upload** — a listing holds one photo, and there's no authentication service.
- **Quick-offer pills inside chat.** Not just a data gap: offers are created with `set()` on a `listingId_buyerId` doc, and `firestore.rules` allows *create* for the buyer with *update* reserved to the seller. A buyer who already has an offer would hit permission-denied on a second tap. That needs offer-state handling before it can ship, not just styling — worth doing as its own change.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 42 pass, unchanged
- [ ] CI

Same caveat as #28: these are presentation changes to screens whose widget trees aren't under test (they need live Firebase). The logic they wrap is untouched and its unit tests still pass, but the rendering itself is verified by review and the CI build, not by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195suo1jDY8EYgt9qC2apSs

---
_Generated by [Claude Code](https://claude.ai/code/session_0195suo1jDY8EYgt9qC2apSs)_